### PR TITLE
Changed in_array to array_key_exists

### DIFF
--- a/library/ZendService/Google/Gcm/Message.php
+++ b/library/ZendService/Google/Gcm/Message.php
@@ -179,7 +179,7 @@ class Message
         if (!is_string($key) || empty($key)) {
             throw new Exception\InvalidArgumentException('$key must be a non-empty string');
         }
-        if (in_array($key, $this->data)) {
+        if (array_key_exists($key, $this->data)) {
             throw new Exception\RuntimeException('$key conflicts with current set data');
         }
         $this->data[$key] = $value;

--- a/tests/ZendService/Google/Gcm/MessageTest.php
+++ b/tests/ZendService/Google/Gcm/MessageTest.php
@@ -97,6 +97,13 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->m->addData(array('1234'), 'value');
     }
 
+    public function testDuplicateDataKeyThrowsException()
+    {
+        $this->setExpectedException('RuntimeException');
+        $this->m->setData($this->validData);
+        $this->m->addData('key', 'value');
+    }
+
     public function testExpectedDelayWhileIdleBehavior()
     {
         $this->assertEquals($this->m->getDelayWhileIdle(), false);


### PR DESCRIPTION
String interpolation only works with double quoted strings and the exception messages have variables included, but are single quoted. This caused exception messages like `$key must be a non-empty string`.

`in_array` in the `addData` method should be `array_key_exists`, since the purpose of the method is to ensure existing `$this->data` keys are not overwritten. `in_array` checks if a value is present in an array, not a key.

Also, using `in_array` without strict checking can cause some unpredictable results (see [docs](http://us1.php.net//manual/en/function.in-array.php#106319)). In this case, I think it is better to use the strict flag in the `addRegistrationId` method.
