### PR TITLE
Added hhvm to TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ php:
 
 before_install:
  - cp tests/TestConfiguration.php.travis tests/TestConfiguration.php
- - composer self-update
  - composer install --dev
 
 script:


### PR DESCRIPTION
There were some issues running TravisCI, e.g. tests/run-tests.php didn't exist and composer is installed by default on TravisCI now.
