### PR TITLE
autoload is wrong for exceptions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "license": "BSD-3-Clause",
     "autoload": {
         "psr-0": {
-            "ZendService\\Google\\Gcm\\": "library/"
+            "ZendService\\Google\\Gcm\\": "library/",
+            "ZendService\\Google\\Exception\\": "library/"
         }
     },
     "repositories": [


### PR DESCRIPTION
After running ``composer update`` I got errors on my installation, as php could not find the class-declarations for the various exceptions. As it turns out, they are missing in the composer.json.

See attached fix.