### PR TITLE
Migrate from GCM to FCM.

### DIFF
--- a/library/ZendService/Google/Gcm/Client.php
+++ b/library/ZendService/Google/Gcm/Client.php
@@ -29,7 +29,7 @@ class Client
     /**
      * @const string Server URI
      */
-    const SERVER_URI = 'https://gcm-http.googleapis.com/gcm/send';
+    const SERVER_URI = 'https://fcm.googleapis.com/fcm/send';
 
     /**
      * @var Zend\Http\Client


### PR DESCRIPTION
As google is migrating from GCM to FirebaseCloudmessaging the endpoinmts are also changed. as stated here. https://developers.google.com/cloud-messaging/android/android-migrate-fcm#update_server_endpoints