### PR TITLE
Support for FCM (#20)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - 7.0
+  - 7
   - hhvm
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,6 @@
         "zendframework/zend-json": ">=2.0.0"
     },
     "require-dev": {
-        "phpunit/PHPUnit": "3.7.*"
+        "phpunit/PHPUnit": "4.8.*"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "repositories": [
         {
             "type": "composer",
-            "url": "http://packages.zendframework.com/"
+            "url": "https://packages.zendframework.com/"
         }
     ],
     "require": {

--- a/library/ZendService/Google/Gcm/Client.php
+++ b/library/ZendService/Google/Gcm/Client.php
@@ -29,10 +29,10 @@ class Client
     /**
      * @const string Server URI
      */
-    const SERVER_URI = 'https://gcm-http.googleapis.com/gcm/send';
+    const SERVER_URI = 'https://fcm.googleapis.com/fcm/send';
 
     /**
-     * @var Zend\Http\Client
+     * @var \Zend\Http\Client
      */
     protected $httpClient;
 
@@ -56,7 +56,7 @@ class Client
      *
      * @param string $apiKey
      * @return Client
-     * @throws InvalidArgumentException
+     * @throws Exception\InvalidArgumentException
      */
     public function setApiKey($apiKey)
     {
@@ -70,7 +70,7 @@ class Client
     /**
      * Get HTTP Client
      *
-     * @return Zend\Http\Client
+     * @return \Zend\Http\Client
      */
     public function getHttpClient()
     {
@@ -96,7 +96,7 @@ class Client
     /**
      * Send Message
      *
-     * @param Mesage $message
+     * @param Message $message
      * @return Response
      * @throws Exception\RuntimeException
      */

--- a/library/ZendService/Google/Gcm/Message.php
+++ b/library/ZendService/Google/Gcm/Message.php
@@ -36,9 +36,19 @@ class Message
     protected $collapseKey;
 
     /**
+     * @var string
+     */
+    protected $priority = 'normal';
+
+    /**
      * @var array
      */
     protected $data = array();
+
+    /**
+     * @var array
+     */
+    protected $notification = array();
 
     /**
      * @var bool
@@ -141,6 +151,32 @@ class Message
     }
 
     /**
+     * Get priority
+     *
+     * @return string
+     */
+    public function getPriority()
+    {
+        return $this->priority;
+    }
+
+    /**
+     * Set priority
+     *
+     * @param string $priority
+     * @return Message
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setPriority($priority)
+    {
+        if (!is_null($priority) && !(is_string($priority) && strlen($priority) > 0)) {
+            throw new Exception\InvalidArgumentException('$priority must be null or a non-empty string');
+        }
+        $this->priority = $priority;
+        return $this;
+    }
+
+    /**
      * Set Data
      *
      * @param array $data
@@ -194,6 +230,63 @@ class Message
     public function clearData()
     {
         $this->data = array();
+        return $this;
+    }
+
+    /**
+     * Set notification
+     *
+     * @param array $data
+     * @return Message
+     */
+    public function setNotification(array $data)
+    {
+        $this->clearNotification();
+        foreach ($data as $k => $v) {
+            $this->addNotification($k, $v);
+        }
+        return $this;
+    }
+
+    /**
+     * Get notification
+     *
+     * @return array
+     */
+    public function getNotification()
+    {
+        return $this->notification;
+    }
+
+    /**
+     * Add notification data
+     *
+     * @param string $key
+     * @param mixed $value
+     * @return Message
+     * @throws Exception\InvalidArgumentException
+     * @throws Exception\RuntimeException
+     */
+    public function addNotification($key, $value)
+    {
+        if (!is_string($key) || empty($key)) {
+            throw new Exception\InvalidArgumentException('$key must be a non-empty string');
+        }
+        if (array_key_exists($key, $this->notification)) {
+            throw new Exception\RuntimeException('$key conflicts with current set data');
+        }
+        $this->notification[$key] = $value;
+        return $this;
+    }
+
+    /**
+     * Clear notification
+     *
+     * @return Message
+     */
+    public function clearNotification()
+    {
+        $this->notification = array();
         return $this;
     }
 
@@ -305,8 +398,14 @@ class Message
         if ($this->collapseKey) {
             $json['collapse_key'] = $this->collapseKey;
         }
+        if ($this->priority) {
+            $json['priority'] = $this->priority;
+        }
         if ($this->data) {
             $json['data'] = $this->data;
+        }
+        if ($this->notification) {
+            $json['notification'] = $this->notification;
         }
         if ($this->delayWhileIdle) {
             $json['delay_while_idle'] = $this->delayWhileIdle;

--- a/library/ZendService/Google/Gcm/Response.php
+++ b/library/ZendService/Google/Gcm/Response.php
@@ -81,7 +81,7 @@ class Response
      * @param string $response
      * @param Message $message
      * @return Response
-     * @throws Exception\ServerUnavailable
+     * @throws Exception\InvalidArgumentException
      */
     public function __construct($response = null, Message $message = null)
     {

--- a/tests/ZendService/Google/Gcm/MessageTest.php
+++ b/tests/ZendService/Google/Gcm/MessageTest.php
@@ -90,6 +90,21 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('data', $this->m->toJson());
     }
 
+    public function testExpectedNotificationBehavior()
+    {
+        $this->assertEquals($this->m->getNotification(), array());
+        $this->assertNotContains('notification', $this->m->toJson());
+        $this->m->setNotification($this->validData);
+        $this->assertEquals($this->m->getNotification(), $this->validData);
+        $this->assertContains('notification', $this->m->toJson());
+        $this->m->clearNotification();
+        $this->assertEquals($this->m->getNotification(), array());
+        $this->assertNotContains('notification', $this->m->toJson());
+        $this->m->addNotification('mykey', 'myvalue');
+        $this->assertEquals($this->m->getNotification(), array('mykey' => 'myvalue'));
+        $this->assertContains('notification', $this->m->toJson());
+    }
+
     public function testInvalidDataThrowsException()
     {
         $this->setExpectedException('InvalidArgumentException');

--- a/tests/ZendService/Google/Gcm/ResponseTest.php
+++ b/tests/ZendService/Google/Gcm/ResponseTest.php
@@ -58,7 +58,11 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidConstructorThrowsException()
     {
-        $this->setExpectedException('PHPUnit_Framework_Error');
+        if( PHP_VERSION_ID >= 70000 ) {
+            $this->setExpectedException('TypeError');
+        } else {
+            $this->setExpectedException('PHPUnit_Framework_Error');
+        }
         $response = new Response('{bad');
     }
 


### PR DESCRIPTION
- Change GCM end-point to FCM
- Make Travis happy
- Test PHP 7.0 (#22)
- Add new parameters from FCM docs (#21) (https://firebase.google.com/docs/cloud-messaging/http-server-ref)
- Some PHP doc fixes
- Update PHPUnit
- Fix Travis for PHP 7 (#9)
