### PR TITLE
delay_while_idle is deprecated

### DIFF
--- a/library/Gcm/Message.php
+++ b/library/Gcm/Message.php
@@ -49,11 +49,6 @@ class Message
     protected $notification = [];
 
     /**
-     * @var bool
-     */
-    protected $delayWhileIdle = false;
-
-    /**
      * @var int
      */
     protected $timeToLive = 2419200;
@@ -309,30 +304,6 @@ class Message
     }
 
     /**
-     * Set Delay While Idle
-     *
-     * @param bool $delay
-     *
-     * @return Message
-     */
-    public function setDelayWhileIdle($delay)
-    {
-        $this->delayWhileIdle = (bool) $delay;
-
-        return $this;
-    }
-
-    /**
-     * Get Delay While Idle.
-     *
-     * @return bool
-     */
-    public function getDelayWhileIdle()
-    {
-        return $this->delayWhileIdle;
-    }
-
-    /**
      * Set Time to Live.
      *
      * @param int $ttl
@@ -433,9 +404,6 @@ class Message
         }
         if ($this->notification) {
             $json['notification'] = $this->notification;
-        }
-        if ($this->delayWhileIdle) {
-            $json['delay_while_idle'] = $this->delayWhileIdle;
         }
         if ($this->timeToLive != 2419200) {
             $json['time_to_live'] = $this->timeToLive;

--- a/tests/Gcm/MessageTest.php
+++ b/tests/Gcm/MessageTest.php
@@ -129,18 +129,6 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->m->addData('key', 'value');
     }
 
-    public function testExpectedDelayWhileIdleBehavior()
-    {
-        self::assertEquals($this->m->getDelayWhileIdle(), false);
-        self::assertNotContains('delay_while_idle', $this->m->toJson());
-        $this->m->setDelayWhileIdle(true);
-        self::assertEquals($this->m->getDelayWhileIdle(), true);
-        self::assertContains('delay_while_idle', $this->m->toJson());
-        $this->m->setDelayWhileIdle(false);
-        self::assertEquals($this->m->getDelayWhileIdle(), false);
-        self::assertNotContains('delay_while_idle', $this->m->toJson());
-    }
-
     public function testExpectedTimeToLiveBehavior()
     {
         self::assertEquals($this->m->getTimeToLive(), 2419200);


### PR DESCRIPTION
Covers #29 by remove deprecated `delay_while_idle` parameter