### PR TITLE
Upgrade zend-json package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "zendframework/zend-http": "^2.0",
-        "zendframework/zend-json": "^2.0"
+        "zendframework/zend-json": "^2.0 || ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.5",


### PR DESCRIPTION
If I install before [ZendService_Apple_Apns](https://github.com/zendframework/ZendService_Apple_Apns) no installable ZendService_Google_Gcm. The `zend-json` upgrade resolve problem.